### PR TITLE
add fastq cleanup to sra path

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -151,3 +151,13 @@ jobs:
       rolename: ${{startsWith(inputs.environment, 'prod') && 'push-glue' || 'push-docker-image'}}
     secrets:
       AWS_ACCOUNT_ID: ${{secrets.AWS_ACCOUNT_ID}}
+
+  build_push_db-seqkit:
+    uses: finddx/seq-treat-tbkb-github-workflows/.github/workflows/build_push.yml@main
+    with:
+      environment:  ${{ github.event.inputs.environment }}
+      repo_name: genomicsworkflow-seqkit
+      workdir: containers/seqkit
+      rolename: ${{startsWith(inputs.environment, 'prod') && 'push-glue' || 'push-docker-image'}}
+    secrets:
+      AWS_ACCOUNT_ID: ${{secrets.AWS_ACCOUNT_ID}}

--- a/containers/seqkit/Dockerfile
+++ b/containers/seqkit/Dockerfile
@@ -1,0 +1,14 @@
+FROM quay.io/biocontainers/seqkit:0.7.1--0
+
+ARG VERSION=0.7.1--0
+
+LABEL container.base.image="quay.io/biocontainers/seqkit:0.7.1--0"
+LABEL software.name="seqkit"
+LABEL software.version=${VERSION}
+LABEL software.description="seqkit is a toolkit for FASTA/Q file manipulation"
+LABEL tags="Genomics"
+
+
+ADD cleanup_normalized_fastq.sh /scripts/
+
+WORKDIR /scratch

--- a/containers/seqkit/cleanup_normalized_fastq.sh
+++ b/containers/seqkit/cleanup_normalized_fastq.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Cleanup normalized FASTQ files using seqkit
+# Usage: cleanup_normalized_fastq.sh <sampleId> <fastqId>
+set -euo pipefail
+
+SAMPLE_ID="$1"
+FASTQ_ID="$2"
+
+cd "$SAMPLE_ID"
+
+# create a list of reads present in both files
+seqkit common $SAMPLE_ID/${FASTQ_ID}_1.fastq.gz $SAMPLE_ID/${FASTQ_ID}_2.fastq.gz | seqkit seq -n -i > $SAMPLE_ID/common_reads.txt
+
+# filter R1 and R2 using the common reads list, compress to new files
+seqkit grep -f $SAMPLE_ID/common_reads.txt $SAMPLE_ID/${FASTQ_ID}_1.fastq > $SAMPLE_ID/${FASTQ_ID}_cleaned_1.fastq
+seqkit grep -f $SAMPLE_ID/common_reads.txt $SAMPLE_ID/${FASTQ_ID}_2.fastq > $SAMPLE_ID/${FASTQ_ID}_cleaned_2.fastq
+
+mv $SAMPLE_ID/${FASTQ_ID}_cleaned_1.fastq $SAMPLE_ID/${FASTQ_ID}_1.fastq
+mv $SAMPLE_ID/${FASTQ_ID}_cleaned_2.fastq $SAMPLE_ID/${FASTQ_ID}_2.fastq
+
+rm $SAMPLE_ID/common_reads.txt

--- a/containers/seqkit/cleanup_normalized_fastq.sh
+++ b/containers/seqkit/cleanup_normalized_fastq.sh
@@ -6,8 +6,6 @@ set -euo pipefail
 SAMPLE_ID="$1"
 FASTQ_ID="$2"
 
-cd "$SAMPLE_ID"
-
 # create a list of reads present in both files
 seqkit common $SAMPLE_ID/${FASTQ_ID}_1.fastq.gz $SAMPLE_ID/${FASTQ_ID}_2.fastq.gz | seqkit seq -n -i > $SAMPLE_ID/common_reads.txt
 

--- a/devops/envs/prod-unicc/batch.tf
+++ b/devops/envs/prod-unicc/batch.tf
@@ -86,6 +86,15 @@ locals {
       container_vcpu   = "1"
       container_memory = "4096"
     }
+    "${local.prefix}-Seqkit" = {
+      image = "${local.account_id}.dkr.ecr.${local.aws_region}.amazonaws.com/${var.project_name}-genomicsworkflow-seqkit:latest"
+      command = [
+        "echo",
+        "test",
+      ]
+      container_vcpu   = "1"
+      container_memory = "4096"
+    }
     "${local.prefix}-Delly" = {
       image = "${local.account_id}.dkr.ecr.${local.aws_region}.amazonaws.com/${var.project_name}-genomicsworkflow-delly:latest"
       command = [

--- a/devops/envs/prod-unicc/pipeline_child.json
+++ b/devops/envs/prod-unicc/pipeline_child.json
@@ -383,7 +383,7 @@
                                 ]
                             },
                             "Parameters": {
-                                "SAMPLE_ID.$": "States.Format('{}', $.SampleId)",
+                                "SAMPLE_ID.$": "$.SampleId",
                                 "FASTQ_ID.$": "$.FastqId"
                             }
                         },

--- a/devops/envs/prod-unicc/pipeline_child.json
+++ b/devops/envs/prod-unicc/pipeline_child.json
@@ -383,7 +383,7 @@
                                 ]
                             },
                             "Parameters": {
-                                "SAMPLE_ID.$": "$.SampleId",
+                                "SAMPLE_ID.$": "States.Format('{}', $.SampleId)",
                                 "FASTQ_ID.$": "$.FastqId"
                             }
                         },

--- a/devops/envs/prod-unicc/pipeline_child.json
+++ b/devops/envs/prod-unicc/pipeline_child.json
@@ -364,6 +364,39 @@
                                 "BackoffRate": 2
                             }
                         ],
+                        "Next": "CleanupNormalizedFastq"
+                    },
+                    "CleanupNormalizedFastq": {
+                        "Type": "Task",
+                        "ResultPath": null,
+                        "Resource": "arn:aws:states:::batch:submitJob.sync",
+                        "Parameters": {
+                            "JobName": "cleanup-normalized-fastq",
+                            "JobDefinition": "${Seqkit}",
+                            "JobQueue.$": "$.JobQueueArn",
+                            "ContainerOverrides": {
+                                "Command": [
+                                    "/bin/bash",
+                                    "/scripts/cleanup_normalized_fastq.sh",
+                                    "Ref::SAMPLE_ID",
+                                    "Ref::FASTQ_ID"
+                                ]
+                            },
+                            "Parameters": {
+                                "SAMPLE_ID.$": "States.Format('{}', $.SampleId)",
+                                "FASTQ_ID.$": "$.FastqId"
+                            }
+                        },
+                        "Retry": [
+                            {
+                                "ErrorEquals": [
+                                    "Batch.AWSBatchException"
+                                ],
+                                "IntervalSeconds": 5,
+                                "MaxAttempts": 10,
+                                "BackoffRate": 2
+                            }
+                        ],
                         "Next": "ParallelFastQC"
                     },
                     "ParallelFastQC": {

--- a/devops/envs/prod-unicc/step_functions.tf
+++ b/devops/envs/prod-unicc/step_functions.tf
@@ -18,7 +18,7 @@ module "pipeline_child" {
       Gatk      = module.batch_job_definition_ec2.batch_job_definition_arn["${local.prefix}-Gatk"]
       Freebayes = module.batch_job_definition_ec2.batch_job_definition_arn["${local.prefix}-Freebayes"]
       Sratools  = module.batch_job_definition_ec2.batch_job_definition_arn["${local.prefix}-Sratools"]
-      Seqkit  = module.batch_job_definition_ec2.batch_job_definition_arn["${local.prefix}-Seqkit"]
+      Seqkit    = module.batch_job_definition_ec2.batch_job_definition_arn["${local.prefix}-Seqkit"]
       Delly     = module.batch_job_definition_ec2.batch_job_definition_arn["${local.prefix}-Delly"]
       Mosdepth  = module.batch_job_definition_ec2.batch_job_definition_arn["${local.prefix}-Mosdepth"]
       Bedtools  = module.batch_job_definition_ec2.batch_job_definition_arn["${local.prefix}-Bedtools"]

--- a/devops/envs/prod-unicc/step_functions.tf
+++ b/devops/envs/prod-unicc/step_functions.tf
@@ -18,6 +18,7 @@ module "pipeline_child" {
       Gatk      = module.batch_job_definition_ec2.batch_job_definition_arn["${local.prefix}-Gatk"]
       Freebayes = module.batch_job_definition_ec2.batch_job_definition_arn["${local.prefix}-Freebayes"]
       Sratools  = module.batch_job_definition_ec2.batch_job_definition_arn["${local.prefix}-Sratools"]
+      Seqkit  = module.batch_job_definition_ec2.batch_job_definition_arn["${local.prefix}-Seqkit"]
       Delly     = module.batch_job_definition_ec2.batch_job_definition_arn["${local.prefix}-Delly"]
       Mosdepth  = module.batch_job_definition_ec2.batch_job_definition_arn["${local.prefix}-Mosdepth"]
       Bedtools  = module.batch_job_definition_ec2.batch_job_definition_arn["${local.prefix}-Bedtools"]


### PR DESCRIPTION
Sometimes there are singleton reads in the forward or reverse read file. This creates issues with mismatching read names that causes `BWA` to fail. This adds an extra step to extract only reads which appear in both forwards and reverse fastq files.