### PR TITLE
Change to low-memory fastq cleanup

### DIFF
--- a/containers/seqkit/cleanup_normalized_fastq.sh
+++ b/containers/seqkit/cleanup_normalized_fastq.sh
@@ -7,13 +7,8 @@ SAMPLE_ID="$1"
 FASTQ_ID="$2"
 
 # create a list of reads present in both files
-seqkit common $SAMPLE_ID/${FASTQ_ID}_1.fastq.gz $SAMPLE_ID/${FASTQ_ID}_2.fastq.gz | seqkit seq -n -i > $SAMPLE_ID/common_reads.txt
+seqkit pair -1 $SAMPLE_ID/${FASTQ_ID}_1.fastq -2 $SAMPLE_ID/${FASTQ_ID}_2.fastq 
 
-# filter R1 and R2 using the common reads list, compress to new files
-seqkit grep -f $SAMPLE_ID/common_reads.txt $SAMPLE_ID/${FASTQ_ID}_1.fastq > $SAMPLE_ID/${FASTQ_ID}_cleaned_1.fastq
-seqkit grep -f $SAMPLE_ID/common_reads.txt $SAMPLE_ID/${FASTQ_ID}_2.fastq > $SAMPLE_ID/${FASTQ_ID}_cleaned_2.fastq
-
-mv $SAMPLE_ID/${FASTQ_ID}_cleaned_1.fastq $SAMPLE_ID/${FASTQ_ID}_1.fastq
-mv $SAMPLE_ID/${FASTQ_ID}_cleaned_2.fastq $SAMPLE_ID/${FASTQ_ID}_2.fastq
-
-rm $SAMPLE_ID/common_reads.txt
+# replace original files with paired reads only
+mv $SAMPLE_ID/${FASTQ_ID}_1.paired.fastq $SAMPLE_ID/${FASTQ_ID}_1.fastq
+mv $SAMPLE_ID/${FASTQ_ID}_2.paired.fastq $SAMPLE_ID/${FASTQ_ID}_2.fastq

--- a/containers/seqkit/cleanup_normalized_fastq.sh
+++ b/containers/seqkit/cleanup_normalized_fastq.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 SAMPLE_ID="$1"
 FASTQ_ID="$2"
 
-# create a list of reads present in both files
+# create paired read files with only reads that have a mate
 seqkit pair -1 $SAMPLE_ID/${FASTQ_ID}_1.fastq -2 $SAMPLE_ID/${FASTQ_ID}_2.fastq 
 
 # replace original files with paired reads only


### PR DESCRIPTION
This PR changes fastq cleanup code to use the `seqkit pair` function which consumes a lot less memory.

Tested on SAMN03653317 and brings down peak memory use from to 5.27 GB to 84.42 MB.